### PR TITLE
feat!: The SpriteSheetAnimation is now an asset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,12 @@ keywords = ["game", "gamedev", "anmiation", "bevy"]
 categories = ["game-development"]
 
 [dependencies]
-bevy_core = "^0.5.0"
-bevy_ecs = "^0.5.0"
-bevy_app = "^0.5.0"
-bevy_reflect = "^0.5.0"
-bevy_sprite = "^0.5.0"
+bevy_core = { version = "^0.5.0", default-features = false }
+bevy_ecs = { version = "^0.5.0", default-features = false }
+bevy_app = { version = "^0.5.0", default-features = false }
+bevy_reflect = { version = "^0.5.0", default-features = false }
+bevy_sprite = { version = "^0.5.0", default-features = false }
+bevy_asset = { version = "^0.5.0", default-features = false }
 
 [dev-dependencies]
 bevy = { version = "^0.5.0", default-features = false, features = ["render", "bevy_wgpu", "x11", "png"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/jcornaz/benimator"
 keywords = ["game", "gamedev", "anmiation", "bevy"]
 categories = ["game-development"]
 
+[features]
+default = ["warnings"]
+warnings = ["bevy_log"]
+
 [dependencies]
 bevy_core = { version = "^0.5.0", default-features = false }
 bevy_ecs = { version = "^0.5.0", default-features = false }
@@ -16,6 +20,7 @@ bevy_app = { version = "^0.5.0", default-features = false }
 bevy_reflect = { version = "^0.5.0", default-features = false }
 bevy_sprite = { version = "^0.5.0", default-features = false }
 bevy_asset = { version = "^0.5.0", default-features = false }
+bevy_log = { version = "^0.5.0", default-features = false, optional = true }
 
 [dev-dependencies]
 bevy = { version = "^0.5.0", default-features = false, features = ["render", "bevy_wgpu", "x11", "png"] }

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Add to `Cargo.toml`:
 benimator = "0.1.1"
 ```
 
+## Cargo features
+
+* `warnings` (enabled by default). Log warnings in case of incorrect usage detected.
+
 ## Bevy Version Compatibility
 
 | bevy | benimator  |

--- a/README.md
+++ b/README.md
@@ -35,9 +35,17 @@ fn spawn(
   mut commands: Commands,
   asset_server: Res<AssetServer>,
   mut textures: ResMut<Assets<TextureAtlas>>,
+  mut animations: ResMut<Assets<SpriteSheetAnimation>>,
 ) {
   // Don't forget the camera ;-)
   commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+
+  // Create an animation
+  // Here we use an index-range (from 0 to 4) where each frame has the same duration
+  let animation_handle = animations.add(SpriteSheetAnimation::from_range(
+    0..=4,
+    Duration::from_millis(100),
+  ));
 
   commands
           // Spawn a bevy sprite-sheet
@@ -46,9 +54,8 @@ fn spawn(
             transform: Transform::from_scale(Vec3::splat(10.0)),
             ..Default::default()
           })
-          // Insert the animation component
-          // Here we use an index-range (from 0 to 4) where each frame has the same duration
-          .insert(SpriteSheetAnimation::from_range(0..=4, Duration::from_millis(100)))
+          // Insert the asset handle of the animation
+          .insert(animation_handle)
           // Start the animation immediately. Remove this component in order to pause the animation.
           .insert(Play);
 }

--- a/examples/change_animation.rs
+++ b/examples/change_animation.rs
@@ -17,11 +17,8 @@ fn main() {
         .init_resource::<Animations>()
         .add_plugins(DefaultPlugins)
         .add_plugin(AnimationPlugin)
-        .add_startup_system(
-            create_animations
-                .system()
-                .chain(spawn_animated_coin.system()),
-        )
+        .add_startup_system_to_stage(StartupStage::PreStartup, create_animations.system())
+        .add_startup_system(spawn_animated_coin.system())
         .add_startup_system(spawn_camera.system())
         .add_system(change_animation.system())
         .run();
@@ -64,10 +61,6 @@ fn spawn_animated_coin(
         .insert(Timer::from_seconds(5.0, true));
 }
 
-fn spawn_camera(mut commands: Commands) {
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
-}
-
 fn change_animation(
     time: Res<Time>,
     animations: Res<Animations>,
@@ -82,4 +75,8 @@ fn change_animation(
             }
         }
     }
+}
+
+fn spawn_camera(mut commands: Commands) {
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
 }

--- a/examples/change_animation.rs
+++ b/examples/change_animation.rs
@@ -1,31 +1,53 @@
+use core::ops::Deref;
 use std::time::Duration;
 
 use bevy::prelude::*;
 
 use benimator::*;
 
-static FAST: Duration = Duration::from_millis(100);
-static SLOW: Duration = Duration::from_millis(250);
+// Create a resource to store handles of the animations
+#[derive(Default)]
+struct Animations {
+    slow: Handle<SpriteSheetAnimation>,
+    fast: Handle<SpriteSheetAnimation>,
+}
 
 fn main() {
     App::build()
+        .init_resource::<Animations>()
         .add_plugins(DefaultPlugins)
-        .add_plugin(AnimationPlugin) // <-- Add the plugin
-        .add_startup_system(spawn.system())
-        .add_system(animation.system())
+        .add_plugin(AnimationPlugin)
+        .add_startup_system(
+            create_animations
+                .system()
+                .chain(spawn_animated_coin.system()),
+        )
+        .add_startup_system(spawn_camera.system())
+        .add_system(change_animation.system())
         .run();
 }
 
-fn spawn(
+fn create_animations(
+    mut handles: ResMut<Animations>,
+    mut assets: ResMut<Assets<SpriteSheetAnimation>>,
+) {
+    handles.fast = assets.add(SpriteSheetAnimation::from_range(
+        0..=4,
+        Duration::from_millis(100),
+    ));
+    handles.slow = assets.add(SpriteSheetAnimation::from_range(
+        0..=4,
+        Duration::from_millis(250),
+    ));
+}
+
+fn spawn_animated_coin(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     mut textures: ResMut<Assets<TextureAtlas>>,
+    animations: Res<Animations>,
 ) {
-    // Don't forget the camera ;-)
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
-
     commands
-        // Spawn a bevy sprite-sheet
         .spawn_bundle(SpriteSheetBundle {
             texture_atlas: textures.add(TextureAtlas::from_grid(
                 asset_server.load("coin.png"),
@@ -36,37 +58,27 @@ fn spawn(
             transform: Transform::from_scale(Vec3::splat(10.0)),
             ..Default::default()
         })
-        // Insert the animation component
-        // Here we use an index-range (from 0 to 4) where each frame has the same duration
-        .insert(SpriteSheetAnimation::from_range(0..=4, FAST))
-        // Start the animation immediately. Remove this component in order to pause the animation.
+        .insert(animations.fast.clone())
         .insert(Play)
-        // Add component and timer to query
-        .insert(Animation::Fast)
+        // Add timer, counting down the time before the animation is changed
         .insert(Timer::from_seconds(5.0, true));
 }
 
-enum Animation {
-    Fast,
-    Slow,
+fn spawn_camera(mut commands: Commands) {
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
 }
 
-fn animation(
+fn change_animation(
     time: Res<Time>,
-    mut query: Query<(&mut Timer, &mut Animation, &mut SpriteSheetAnimation)>,
+    animations: Res<Animations>,
+    mut query: Query<(&mut Timer, &mut Handle<SpriteSheetAnimation>)>,
 ) {
-    if let Ok((mut timer, mut animation, mut sprite_sheet_animation)) = query.single_mut() {
-        timer.tick(time.delta());
-        if timer.finished() {
-            match *animation {
-                Animation::Fast => {
-                    *animation = Animation::Slow;
-                    *sprite_sheet_animation = SpriteSheetAnimation::from_range(0..=4, SLOW);
-                }
-                Animation::Slow => {
-                    *animation = Animation::Fast;
-                    *sprite_sheet_animation = SpriteSheetAnimation::from_range(0..=4, FAST);
-                }
+    if let Ok((mut timer, mut animation)) = query.single_mut() {
+        if timer.tick(time.delta()).finished() {
+            if animation.deref() == &animations.fast {
+                *animation = animations.slow.clone();
+            } else {
+                *animation = animations.fast.clone();
             }
         }
     }

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -16,9 +16,17 @@ fn spawn(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     mut textures: ResMut<Assets<TextureAtlas>>,
+    mut animations: ResMut<Assets<SpriteSheetAnimation>>,
 ) {
     // Don't forget the camera ;-)
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+
+    // Create an animation
+    // Here we use an index-range (from 0 to 4) where each frame has the same duration
+    let animation_handle = animations.add(SpriteSheetAnimation::from_range(
+        0..=4,
+        Duration::from_millis(100),
+    ));
 
     commands
         // Spawn a bevy sprite-sheet
@@ -32,12 +40,8 @@ fn spawn(
             transform: Transform::from_scale(Vec3::splat(10.0)),
             ..Default::default()
         })
-        // Insert the animation component
-        // Here we use an index-range (from 0 to 4) where each frame has the same duration
-        .insert(SpriteSheetAnimation::from_range(
-            0..=4,
-            Duration::from_millis(100),
-        ))
+        // Insert the asset handle of the animation
+        .insert(animation_handle)
         // Start the animation immediately. Remove this component in order to pause the animation.
         .insert(Play);
 }

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use bevy_ecs::prelude::*;
 use bevy_reflect::{Reflect, TypeUuid};
 
-/// Component to animate the `TextureAtlasSprite` of the same entity
+/// Asset that define an animation of `TextureAtlasSprite`
 ///
 /// See crate level documentation for usage
 #[derive(Debug, Clone, Default, Reflect, TypeUuid)]

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -2,13 +2,14 @@ use std::ops::RangeInclusive;
 use std::time::Duration;
 
 use bevy_ecs::prelude::*;
-use bevy_reflect::prelude::*;
+use bevy_reflect::{Reflect, TypeUuid};
 
 /// Component to animate the `TextureAtlasSprite` of the same entity
 ///
 /// See crate level documentation for usage
-#[derive(Debug, Clone, Default, Reflect)]
+#[derive(Debug, Clone, Default, Reflect, TypeUuid)]
 #[reflect(Component)]
+#[uuid = "6378e9c2-ecd1-4029-9cd5-801caf68517c"]
 pub struct SpriteSheetAnimation {
     /// Frames
     pub frames: Vec<Frame>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! fn spawn() { /* ... */ }
 //! ```
 //!
-//! 2. Create [`SpriteSheetAnimation`] and insert the asset handle to the sprite sheet entity you want to animate
+//! 2. Create a [`SpriteSheetAnimation`] and insert the asset handle to the sprite sheet entity you want to animate
 //!
 //! ```
 //! # use std::time::Duration;
@@ -63,28 +63,23 @@
 //!
 //! ```
 //! # use std::time::Duration;
-//! # use bevy::prelude::*;
 //! # use benimator::*;
-//! # fn spawn(mut commands: Commands, mut animations: ResMut<Assets<SpriteSheetAnimation>>) {
-//! commands
-//!     .spawn_bundle(SpriteSheetBundle { ..Default::default() })
-//!     .insert(animations.add(
-//!         SpriteSheetAnimation::from_range(0..=2, Duration::from_millis(100))
-//!             .once() // <-- Runs the animation only once
-//!     ))
-//!     .insert(Play); // <-- This component will be automatically removed once the animation is finished
-//! # }
+//! SpriteSheetAnimation::from_range(0..=2, Duration::from_millis(100))
+//!      .once(); // <-- Runs the animation only once
 //! ```
+//!
+//! Note that, for animations that run once, the `Play` component is automatically removed when the animation is done.
+//! So you can use the `RemovedComponents<Play>` system parameter to execute logic at the end of the animation.
 //!
 //! ## Play/Pause
 //!
-//! Animations proceed only if the [`Play`] component is in the entity.
+//! Animations proceed only if the [`Play`] component is present in the entity.
 //!
 //! To pause or resume an animation, simply remove/insert the [`Play`] component.
 //!
 //! ## Fine-grained frame-duration
 //!
-//! For more precise configuration, it is possible to define the duration of each frame:
+//! For a more precise configuration, it is possible to define the duration of each frame:
 //!
 //! ```rust
 //! # use benimator::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@
 extern crate rstest;
 
 use bevy_app::prelude::*;
+use bevy_asset::AddAsset;
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
 
@@ -129,7 +130,7 @@ pub struct Play;
 
 impl Plugin for AnimationPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        app.register_type::<SpriteSheetAnimation>()
+        app.add_asset::<SpriteSheetAnimation>()
             .add_system_set(state::update_systems())
             .add_system_to_stage(CoreStage::PostUpdate, state::post_update_system());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,24 +30,28 @@
 //! fn spawn() { /* ... */ }
 //! ```
 //!
-//! 2. Insert the [`SpriteSheetAnimation`] component to the sprite sheets you want to animate
+//! 2. Create [`SpriteSheetAnimation`] and insert the asset handle to the sprite sheet entity you want to animate
 //!
 //! ```
 //! # use std::time::Duration;
 //! # use bevy::prelude::*;
 //! # use benimator::*;
 //!
-//! fn spawn(mut commands: Commands) {
+//! fn spawn(mut commands: Commands, mut animations: ResMut<Assets<SpriteSheetAnimation>>) {
+//!
+//!     // Create an animation
+//!     let animation_handle = animations.add(SpriteSheetAnimation::from_range(
+//!         0..=2,                               // Indices of the sprite atlas
+//!         Duration::from_secs_f64(1.0 / 12.0), // Duration of each frame
+//!     ));
+//!     
 //!     commands
 //!         .spawn_bundle(SpriteSheetBundle {
 //!             // TODO: Configure the sprite sheet
 //!             ..Default::default()
 //!         })
-//!         // Insert the animation component
-//!         .insert(SpriteSheetAnimation::from_range(
-//!             0..=2,                               // Indices of the sprite atlas
-//!             Duration::from_secs_f64(1.0 / 12.0), // Duration of each frame
-//!         ))
+//!         // Insert the asset handle of the animation
+//!         .insert(animation_handle)
 //!         // Start the animation immediately
 //!         .insert(Play);
 //! }
@@ -61,13 +65,13 @@
 //! # use std::time::Duration;
 //! # use bevy::prelude::*;
 //! # use benimator::*;
-//! # fn spawn(mut commands: Commands) {
+//! # fn spawn(mut commands: Commands, mut animations: ResMut<Assets<SpriteSheetAnimation>>) {
 //! commands
 //!     .spawn_bundle(SpriteSheetBundle { ..Default::default() })
-//!     .insert(
+//!     .insert(animations.add(
 //!         SpriteSheetAnimation::from_range(0..=2, Duration::from_millis(100))
 //!             .once() // <-- Runs the animation only once
-//!     )
+//!     ))
 //!     .insert(Play); // <-- This component will be automatically removed once the animation is finished
 //! # }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,9 @@ pub use animation::{AnimationMode, Frame, SpriteSheetAnimation};
 mod animation;
 mod state;
 
+#[cfg(feature = "warnings")]
+mod warnings;
+
 /// Plugin to enable sprite-sheet animation
 ///
 /// See crate level documentation for usage
@@ -132,5 +135,8 @@ impl Plugin for AnimationPlugin {
         app.add_asset::<SpriteSheetAnimation>()
             .add_system_set(state::update_systems())
             .add_system_to_stage(CoreStage::PostUpdate, state::post_update_system());
+
+        #[cfg(feature = "warnings")]
+        app.add_system_set(warnings::systems());
     }
 }

--- a/src/warnings.rs
+++ b/src/warnings.rs
@@ -1,0 +1,14 @@
+use bevy_ecs::prelude::*;
+use bevy_log::prelude::*;
+
+use crate::SpriteSheetAnimation;
+
+pub(crate) fn systems() -> SystemSet {
+    SystemSet::new().with_system(report_animation_used_as_component.system())
+}
+
+fn report_animation_used_as_component(query: Query<'_, Entity, Added<SpriteSheetAnimation>>) {
+    if query.iter().next().is_some() {
+        warn!("A SpriteSheetAnimation was inserted as a component. That has no effect. The animations should be added to `Assets<SpriteSheetAnimation>` and the asset-handle inserted as a component.");
+    }
+}

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -3,22 +3,27 @@ extern crate rstest;
 
 use std::time::Duration;
 
+use bevy::asset::AssetPlugin;
 use bevy::prelude::*;
 use bevy_core::CorePlugin;
 
 use benimator::*;
-use bevy::asset::AssetPlugin;
 
 #[rstest]
 fn repeated(mut app: App) {
+    let animation = app
+        .world
+        .get_resource_mut::<Assets<SpriteSheetAnimation>>()
+        .unwrap()
+        .add(SpriteSheetAnimation::from_range(
+            0..=2,
+            Duration::from_nanos(0),
+        ));
+
     let entity = app
         .world
         .spawn()
-        .insert_bundle((
-            TextureAtlasSprite::new(0),
-            SpriteSheetAnimation::from_range(0..=2, Duration::from_nanos(0)),
-            Play,
-        ))
+        .insert_bundle((TextureAtlasSprite::new(0), animation, Play))
         .id();
 
     app.update();
@@ -42,14 +47,16 @@ fn repeated(mut app: App) {
 
 #[rstest]
 fn run_once(mut app: App) {
+    let animation = app
+        .world
+        .get_resource_mut::<Assets<SpriteSheetAnimation>>()
+        .unwrap()
+        .add(SpriteSheetAnimation::from_range(0..=2, Duration::from_nanos(0)).once());
+
     let entity = app
         .world
         .spawn()
-        .insert_bundle((
-            TextureAtlasSprite::new(0),
-            SpriteSheetAnimation::from_range(0..=2, Duration::from_nanos(0)).once(),
-            Play,
-        ))
+        .insert_bundle((TextureAtlasSprite::new(0), animation, Play))
         .id();
 
     app.update();

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -7,6 +7,7 @@ use bevy::prelude::*;
 use bevy_core::CorePlugin;
 
 use benimator::*;
+use bevy::asset::AssetPlugin;
 
 #[rstest]
 fn repeated(mut app: App) {
@@ -77,7 +78,10 @@ fn run_once(mut app: App) {
 fn app() -> App {
     let mut builder = App::build();
 
-    builder.add_plugin(CorePlugin).add_plugin(AnimationPlugin);
+    builder
+        .add_plugin(CorePlugin)
+        .add_plugin(AssetPlugin)
+        .add_plugin(AnimationPlugin);
 
     builder.app
 }


### PR DESCRIPTION
## This is a breaking change!

The `SpriteSheetAnimation` is now an asset. Which means, one has to insert a `Handle<SpriteSheetAnimation>` created via `Assets::<SpriteSheetAnimation>::add` instead of using the `SpriteSheetAnimation` directly as a component. See the examples for more details.

* Now the animation can be created once and reused many times. Even with some different sprite-sheets, as long as they share the same frame indices, durations and animation mode (once or repeat). 
* It is now easier to check what is the current animation as the `Handle` is a unique identifier of the animation.
* Current animation is now easier (and cheaper) to change, as we no longer need to create a new animation each time. (look at the `change_animation` for an examble)

It also opens the door for storing animations ar `ron` (or equivalent) and load them using the asset server, bringing hot-reload support out-of-the-box. (But that's not part of this PR)

Resolve #2

## Remaining tasks
* [x] Log an error when `SpriteSheetAnimation` is used as a component.