### PR TITLE
Fix bug related to once animations

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -45,6 +45,7 @@ impl SpriteSheetAnimationState {
             } else if matches!(animation.mode, AnimationMode::Repeat) {
                 self.current_frame = 0;
             } else {
+                self.current_frame = 0;
                 return true;
             }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -46,6 +46,7 @@ impl SpriteSheetAnimationState {
                 self.current_frame = 0;
             } else {
                 self.current_frame = 0;
+                self.elapsed_in_frame = Duration::ZERO;
                 return true;
             }
 
@@ -370,6 +371,19 @@ mod tests {
                 frame_duration: Duration,
             ) {
                 assert!(state.update(&mut sprite_at_second_frame, &animation, frame_duration))
+            }
+
+            #[rstest]
+            fn returns_to_initial_state(
+                mut state: SpriteSheetAnimationState,
+                mut sprite_at_second_frame: TextureAtlasSprite,
+                animation: SpriteSheetAnimation,
+                frame_duration: Duration,
+            ) {
+                state.update(&mut sprite_at_second_frame, &animation, frame_duration);
+                let expected_state = SpriteSheetAnimationState::default();
+                assert_eq!(state.current_frame, expected_state.current_frame);
+                assert_eq!(state.elapsed_in_frame, expected_state.elapsed_in_frame);
             }
         }
     }


### PR DESCRIPTION
If we do not set `self.current_frame = 0;` when a `Once` animation has finished, then the animation is never able to be executed again.

With this update, the animation is able to be properly restarted next time the `Play` component is added to the corresponding entity.