### PR TITLE
feat: create ping pong animation mode

### DIFF
--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -1,0 +1,43 @@
+use std::time::Duration;
+
+use bevy::prelude::*;
+
+use benimator::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(AnimationPlugin)
+        .add_startup_system(spawn.system())
+        .run();
+}
+
+fn spawn(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut textures: ResMut<Assets<TextureAtlas>>,
+    mut animations: ResMut<Assets<SpriteSheetAnimation>>,
+) {
+    // Don't forget the camera ;-)
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+
+    // Create an animation
+    // Here we use an index-range (from 0 to 4) where each frame has the same duration
+    let animation_handle = animations
+        .add(SpriteSheetAnimation::from_range(0..=4, Duration::from_millis(100)).ping_pong());
+
+    commands
+        // Spawn a bevy sprite-sheet
+        .spawn_bundle(SpriteSheetBundle {
+            texture_atlas: textures.add(TextureAtlas::from_grid(
+                asset_server.load("coin.png"),
+                Vec2::new(16.0, 16.0),
+                5,
+                1,
+            )),
+            transform: Transform::from_scale(Vec3::splat(10.0)),
+            ..Default::default()
+        })
+        .insert(animation_handle)
+        .insert(Play);
+}

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -23,6 +23,10 @@ pub enum AnimationMode {
 
     /// Repeat the animation forever
     Repeat,
+
+    /// Repeat the animation forever, going back and forth between
+    /// the first and last frame.
+    PingPong,
 }
 
 /// A single animation frame
@@ -86,6 +90,13 @@ impl SpriteSheetAnimation {
     #[must_use]
     pub fn repeat(mut self) -> Self {
         self.mode = AnimationMode::Repeat;
+        self
+    }
+
+    /// Set the animation mode to [`AnimationMode::PingPong`]
+    #[must_use]
+    pub fn ping_pong(mut self) -> Self {
+        self.mode = AnimationMode::PingPong;
         self
     }
 

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -15,7 +15,7 @@ pub struct SpriteSheetAnimation {
     pub mode: AnimationMode,
 }
 
-/// Animation mode (run once or repeat)
+/// Animation mode (run once, repeat or ping-pong)
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum AnimationMode {
     /// Runs the animation once and then stop playing

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -12,7 +12,7 @@ pub struct SpriteSheetAnimation {
     /// Frames
     pub frames: Vec<Frame>,
     /// Animation mode
-    pub mode: AnimationMode,
+    pub(crate) mode: AnimationMode,
 }
 
 /// Animation mode (run once, repeat or ping-pong)
@@ -61,14 +61,13 @@ impl SpriteSheetAnimation {
     /// # Example
     ///
     /// ```
-    /// # use benimator::{AnimationMode, SpriteSheetAnimation};
+    /// # use benimator::SpriteSheetAnimation;
     /// # use std::time::Duration;
     /// // Easily create a reversed animation
     /// let animation = SpriteSheetAnimation::from_iter((0..5).rev(), Duration::from_millis(100));
     ///
     /// assert_eq!(animation.frames.iter().map(|frame| frame.index).collect::<Vec<_>>(), vec![4, 3, 2, 1, 0]);
     /// assert!(animation.frames.iter().all(|frame| frame.duration.as_millis() == 100));
-    /// assert_eq!(animation.mode, AnimationMode::Repeat);
     /// ```
     ///
     /// For more granular configuration, see [`from_frames`](SpriteSheetAnimation::from_frames)

--- a/src/state.rs
+++ b/src/state.rs
@@ -75,19 +75,17 @@ impl SpriteSheetAnimationState {
                 }
                 AnimationMode::PingPong => {
                     if self.going_backward {
-                        if self.current_frame != 0 {
-                            self.current_frame -= 1;
-                        } else {
+                        if self.current_frame == 0 {
                             self.going_backward = false;
                             self.current_frame += 1;
-                        }
-                    } else {
-                        if self.current_frame < animation.frames.len() - 1 {
-                            self.current_frame += 1;
                         } else {
-                            self.going_backward = true;
                             self.current_frame -= 1;
                         }
+                    } else if self.current_frame < animation.frames.len() - 1 {
+                        self.current_frame += 1;
+                    } else {
+                        self.going_backward = true;
+                        self.current_frame -= 1;
                     }
                 }
                 AnimationMode::Once => {

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -81,6 +81,51 @@ fn run_once(mut app: App) {
     );
 }
 
+#[rstest]
+fn run_ping_pong(mut app: App) {
+    let animation = app
+        .world
+        .get_resource_mut::<Assets<SpriteSheetAnimation>>()
+        .unwrap()
+        .add(SpriteSheetAnimation::from_range(0..=2, Duration::from_nanos(0)).ping_pong());
+
+    let entity = app
+        .world
+        .spawn()
+        .insert_bundle((TextureAtlasSprite::new(0), animation, Play))
+        .id();
+
+    app.update();
+    assert_eq!(
+        app.world.get::<TextureAtlasSprite>(entity).unwrap().index,
+        1
+    );
+
+    app.update();
+    assert_eq!(
+        app.world.get::<TextureAtlasSprite>(entity).unwrap().index,
+        2
+    );
+
+    app.update();
+    assert_eq!(
+        app.world.get::<TextureAtlasSprite>(entity).unwrap().index,
+        1
+    );
+
+    app.update();
+    assert_eq!(
+        app.world.get::<TextureAtlasSprite>(entity).unwrap().index,
+        0
+    );
+
+    app.update();
+    assert_eq!(
+        app.world.get::<TextureAtlasSprite>(entity).unwrap().index,
+        1
+    );
+}
+
 #[fixture]
 fn app() -> App {
     let mut app = App::new();


### PR DESCRIPTION
Allows the creation of animations using the PingPong mode. This is a WIP solution, there may be alternative implementations.

A possible implementation would be to insert state into the PingPong mode, so that users of the Repeat and Once AnimationMode's would not pay in storage for the PingPong logic.

The problem with this approach is that users would either:
- See the internal logic inside the PingPong mode
- Not be able to construct PingPong directly (AnimationMode fields are made private to improve API).

Closes #11