### PR TITLE
feat: add repeat-from animation mode

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -12,10 +12,16 @@ pub struct SpriteSheetAnimation {
     /// Frames
     pub(crate) frames: Vec<Frame>,
     /// Animation mode
-    pub(crate) mode: AnimationMode,
+    pub(crate) mode: Mode,
 }
 
 /// Animation mode (run once, repeat or ping-pong)
+///
+/// Deprecated
+/// ---
+/// This is not exposed in any of the public APIs of the crate so there is no reason to depend on
+/// it. Use 'builder-style' methods like [`SpriteSheetAnimation::repeat`] instead.
+#[deprecated]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum AnimationMode {
@@ -45,7 +51,7 @@ impl SpriteSheetAnimation {
     pub fn from_frames(frames: Vec<Frame>) -> Self {
         Self {
             frames,
-            mode: AnimationMode::default(),
+            mode: Mode::default(),
         }
     }
 
@@ -76,24 +82,32 @@ impl SpriteSheetAnimation {
             .collect()
     }
 
-    /// Set the animation mode to [`AnimationMode::Once`]
+    /// Runs the animation once and then stop playing
     #[must_use]
     pub fn once(mut self) -> Self {
-        self.mode = AnimationMode::Once;
+        self.mode = Mode::Once;
         self
     }
 
-    /// Set the animation mode to [`AnimationMode::Repeat`]
+    /// Repeat the animation forever
     #[must_use]
     pub fn repeat(mut self) -> Self {
-        self.mode = AnimationMode::Repeat;
+        self.mode = Mode::RepeatFrom(0);
         self
     }
 
-    /// Set the animation mode to [`AnimationMode::PingPong`]
+    /// Repeat the animation forever, from a given frame index (loop back to it at the end of the
+    /// animation)
+    #[must_use]
+    pub fn repeat_from(mut self, frame_index: usize) -> Self {
+        self.mode = Mode::RepeatFrom(frame_index);
+        self
+    }
+
+    /// Repeat the animation forever, going back and forth between the first and last frame.
     #[must_use]
     pub fn ping_pong(mut self) -> Self {
-        self.mode = AnimationMode::PingPong;
+        self.mode = Mode::PingPong;
         self
     }
 
@@ -102,12 +116,27 @@ impl SpriteSheetAnimation {
     }
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub(crate) enum Mode {
+    Once,
+    RepeatFrom(usize),
+    PingPong,
+}
+
 impl FromIterator<Frame> for SpriteSheetAnimation {
     fn from_iter<T: IntoIterator<Item = Frame>>(iter: T) -> Self {
         Self::from_frames(iter.into_iter().collect())
     }
 }
 
+impl Default for Mode {
+    #[inline]
+    fn default() -> Self {
+        Self::RepeatFrom(0)
+    }
+}
+
+#[allow(deprecated)]
 impl Default for AnimationMode {
     #[inline]
     fn default() -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //!         0..=2,                               // Indices of the sprite atlas
 //!         Duration::from_secs_f64(1.0 / 12.0), // Duration of each frame
 //!     ));
-//!     
+//!
 //!     commands
 //!         .spawn_bundle(SpriteSheetBundle {
 //!             // TODO: Configure the sprite sheet
@@ -117,8 +117,11 @@ use bevy_ecs::component::SparseStorage;
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
 
-pub use animation::{AnimationMode, Frame, SpriteSheetAnimation};
+pub use animation::{Frame, SpriteSheetAnimation};
 pub use state::SpriteSheetAnimationState;
+
+#[allow(deprecated)]
+pub use animation::AnimationMode;
 
 mod animation;
 mod state;


### PR DESCRIPTION
Adds `AnimationMode::RepeatFrom(index)` which repeats from a given index rather than going all the way back to zero. This super handy for simple animations like e.g. a torch being lit then staying lit, or a missile lighting up its motor and then looping.    

Because `AnimationMode` is `non_exhaustive` I believe this is not a breaking change.

I considered getting rid of `AnimiationMode::Repeat` and using `Animation::RepeatFrom(0)` in `fn repeat(self)`, but we can't do this without a breaking change.

I was wondering, why even expose the `AnimationMode` enum? It looks to me like it's not actually returned or taken as argument by any APIs. Could it be private to the crate? It would make it easier to make changes like this, which generalise an existing animation mode without it being a breaking change.