### PR TITLE
chore: run clippy on all target (incl. tests)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           override: true
           components: clippy, rustfmt
       - run: cargo fmt --all -- --check
-      - run: cargo clippy --all-features
+      - run: cargo clippy --all-features --all-targets
 
   documentation:
     runs-on: ubuntu-latest

--- a/src/state.rs
+++ b/src/state.rs
@@ -301,7 +301,7 @@ mod tests {
             animation: SpriteSheetAnimation,
             frame_duration: Duration,
         ) {
-            assert!(!state.update(&mut sprite_at_second_frame, &animation, frame_duration))
+            assert!(!state.update(&mut sprite_at_second_frame, &animation, frame_duration));
         }
     }
 
@@ -359,7 +359,7 @@ mod tests {
                 animation: SpriteSheetAnimation,
                 frame_duration: Duration,
             ) {
-                assert!(!state.update(&mut sprite_at_second_frame, &animation, frame_duration))
+                assert!(!state.update(&mut sprite_at_second_frame, &animation, frame_duration));
             }
         }
 
@@ -406,7 +406,7 @@ mod tests {
                 animation: SpriteSheetAnimation,
                 frame_duration: Duration,
             ) {
-                assert!(!state.update(&mut sprite_at_second_frame, &animation, frame_duration))
+                assert!(!state.update(&mut sprite_at_second_frame, &animation, frame_duration));
             }
         }
     }
@@ -459,7 +459,7 @@ mod tests {
                 animation: SpriteSheetAnimation,
                 frame_duration: Duration,
             ) {
-                assert!(state.update(&mut sprite_at_second_frame, &animation, frame_duration))
+                assert!(state.update(&mut sprite_at_second_frame, &animation, frame_duration));
             }
 
             #[rstest]


### PR DESCRIPTION
Clippy wasn't running on the test code, so I added `--all-targets` to the github action, and fixed some missing semicolons it caught.

Based on #40 to avoid conflicts with myself; happy to drop the commit from this one if you'd rather.