### PR TITLE
Fix delayed animation start when switching to a new animation.

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -106,11 +106,9 @@ impl SpriteSheetAnimationState {
 
             self.elapsed_in_frame -= frame.duration;
             frame = animation.frames[self.current_frame];
-            sprite.index = frame.index;
         }
-        if sprite.index > frame.index {
-            sprite.index = frame.index;
-        }
+
+        sprite.index = frame.index;
 
         false
     }


### PR DESCRIPTION
The `SpriteSheetAnimationState` `update` function doesn't always update
the sprite index to match the current frame index. When changing
animations, this delays update of `sprite.index` until after the first
frame duration has elapsed.

To fix this, always update the sprite index to match the current frame.