### PR TITLE
feat!: make the integration with `bevy_app` optional and disabled by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,22 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
-  test:
+  test-no-feature:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          override: true
+          profile: minimal
+      - uses: Swatinem/rust-cache@v1
+      - run: cargo check --all-targets --no-default-features
+      - run: cargo test --no-default-features
+
+  test-default-features:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -44,11 +59,20 @@ jobs:
           override: true
           profile: minimal
       - uses: Swatinem/rust-cache@v1
+      - run: cargo check --all-targets --all-features
       - run: cargo test --all-features
 
-  test-unstable-load-from-file:
+  test-feature:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      matrix:
+        feature:
+          - "unstable-load-from-file, yaml"
+          - "unstable-load-from-file, ron"
+          - "bevy-07"
+          - "bevy-app-07"
+
     steps:
       - uses: actions/checkout@v3
       - name: Install rust toolchain
@@ -58,8 +82,8 @@ jobs:
           override: true
           profile: minimal
       - uses: Swatinem/rust-cache@v1
-      - run: cargo test --features "unstable-load-from-file, yaml"
-      - run: cargo test --features "unstable-load-from-file, ron"
+      - run: cargo check --all-targets --no-default-features --features "${{ matrix.feature }}"
+      - run: cargo test --no-default-features --features "${{ matrix.feature }}"
 
   code-style:
     runs-on: ubuntu-latest
@@ -117,7 +141,11 @@ jobs:
   release:
     if: ${{ github.event_name != 'pull_request' }}
     needs:
-      [test, test-all-features, test-unstable-load-from-file, documentation]
+      - test-no-feature
+      - test-default-features
+      - test-all-features
+      - test-feature
+      - documentation
     environment: release
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,12 @@ all-features = true
 [features]
 default = []
 unstable-load-from-file = ["serde", "anyhow", "bevy_utils"]
+bevy-07 = ["bevy-app-07"]
 
 [dependencies]
 bevy_core = { version = "0.7.0", default-features = false }
 bevy_ecs = { version = "0.7.0", default-features = false }
-bevy_app = { version = "0.7.0", default-features = false }
+bevy-app-07 = { package = "bevy_app",version = "0.7.0", default-features = false, optional = true }
 bevy_reflect = { version = "0.7.0", default-features = false }
 bevy_sprite = { version = "0.7.0", default-features = false }
 bevy_asset = { version = "0.7.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,24 @@ rustc_version = "0.4.0"
 [[bench]]
 name = "play_component"
 harness = false
+required-features = ["bevy-07"]
+
+[[example]]
+name = "change_animation"
+required-features = ["bevy-07"]
+
+[[example]]
+name = "end_of_animation_detection"
+required-features = ["bevy-07"]
+
+[[example]]
+name = "ping_pong"
+required-features = ["bevy-07"]
+
+[[example]]
+name = "readme"
+required-features = ["bevy-07"]
 
 [[example]]
 name = "using_animation_file"
-required-features = ["unstable-load-from-file", "yaml"]
+required-features = ["unstable-load-from-file", "yaml", "bevy-07"]

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ cargo add benimator
 
 * `yaml` deserialization from yaml asset files (also requires `unstable-load-from-file`)
 * `ron` deserialization from ron asset files (also requires `unstable-load-from-file`)
+* `bevy-07` all integrations with bevy 0.7
+* `bevy-app-07` integration with `bevy_app` 0.7 (incl. bevy plugin)
 
 ### Unstable features
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,7 @@ mod state;
 ///
 /// See crate level documentation for usage
 #[non_exhaustive]
+#[cfg(feature = "bevy-app-07")]
 #[derive(Default)]
 pub struct AnimationPlugin;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,22 +14,27 @@
 //!
 //! 1. Add the [`AnimationPlugin`] plugin
 //!
-//! ```no_run
-//! use std::time::Duration;
-//! use bevy::prelude::*;
-//! use benimator::*;
+#![cfg_attr(
+    feature = "bevy-app-07",
+    doc = "
+```no_run
+# use bevy::prelude::*;
+use benimator::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(AnimationPlugin::default()) // <-- Enable sprite-sheet animations
+        .add_startup_system(spawn)
+        // ...
+        .run()
+}
+
+fn spawn() { /* ... */ }
+```
+"
+)]
 //!
-//! fn main() {
-//!     App::new()
-//!         .add_plugins(DefaultPlugins)
-//!         .add_plugin(AnimationPlugin::default()) // <-- Enable sprite-sheet animations
-//!         .add_startup_system(spawn.system())
-//!         // ...
-//!         .run()
-//! }
-//!
-//! fn spawn() { /* ... */ }
-//! ```
 //!
 //! 2. Create a [`SpriteSheetAnimation`] and insert the asset handle to the sprite sheet entity you want to animate
 //!

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,14 +8,6 @@ use bevy_sprite::prelude::*;
 
 use crate::{animation::Mode, Play, PlaySpeedMultiplier, SpriteSheetAnimation};
 
-pub(crate) fn maintenance_systems() -> SystemSet {
-    SystemSet::new().with_system(insert).with_system(remove)
-}
-
-pub(crate) fn post_update_systems() -> SystemSet {
-    SystemSet::new().with_system(animate)
-}
-
 /// Animation state component which is automatically inserted/removed
 ///
 /// It can be used to reset the animation state.
@@ -114,7 +106,7 @@ impl SpriteSheetAnimationState {
     }
 }
 
-fn insert(
+pub(crate) fn insert(
     mut commands: Commands<'_, '_>,
     query: Query<
         '_,
@@ -133,7 +125,7 @@ fn insert(
     }
 }
 
-fn remove(
+pub(crate) fn remove(
     mut commands: Commands<'_, '_>,
     removed: RemovedComponents<'_, Handle<SpriteSheetAnimation>>,
 ) {
@@ -152,7 +144,7 @@ type AnimationSystemQuery<'a> = (
     Option<&'a PlaySpeedMultiplier>,
 );
 
-fn animate(
+pub(crate) fn animate(
     mut commands: Commands<'_, '_>,
     time: Res<'_, Time>,
     animation_defs: Res<'_, Assets<SpriteSheetAnimation>>,

--- a/tests/bevy_spec.rs
+++ b/tests/bevy_spec.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "bevy-07")]
+
 use std::time::Duration;
 
 use bevy::asset::AssetPlugin;


### PR DESCRIPTION
This change makes the integration with `bevy_app` optional and disabled by default.

The bevy plugin implementation is available only if this optional dependency is enabled.

To enable this integration (and make the bevy plugin available) one must enable the `bevy-app-07` feature flag.

This marks the beginning of the development of the next major version of benimator (version 4.0.0), for which I will try to make all bevy dependencies entirely optional so that I untie benimator's API stability from bevy's.

See the [related decision](https://github.com/jcornaz/benimator/blob/main/doc/adr/0002-optional-bevy-dependency.md) for more information.