### PR TITLE
feat!: make bevy-sprite dependency optional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
           - "unstable-load-from-file, ron"
           - "bevy-07"
           - "bevy-app-07"
+          - "bevy-sprite-07"
 
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,20 +16,20 @@ all-features = true
 [features]
 default = []
 unstable-load-from-file = ["serde", "anyhow", "bevy_utils"]
-bevy-07 = ["bevy-app-07"]
+bevy-07 = ["bevy-app-07", "bevy-sprite-07"]
 
 [dependencies]
 # Private dependencies (do not leak into the public API)
 yaml = { package = "serde_yaml", version = "0.8.25", default-features = false, optional = true }
 ron = { version = "0.7.1", default-features = false, optional = true }
 
-# Private dependencies (Present in the public API)
+# Public dependencies (Present in the public API)
 bevy_core = { version = "0.7.0", default-features = false }
 bevy_ecs = { version = "0.7.0", default-features = false }
-bevy-app-07 = { package = "bevy_app",version = "0.7.0", default-features = false, optional = true }
 bevy_reflect = { version = "0.7.0", default-features = false }
-bevy_sprite = { version = "0.7.0", default-features = false }
 bevy_asset = { version = "0.7.0", default-features = false }
+bevy-app-07 = { package = "bevy_app",version = "0.7.0", default-features = false, optional = true }
+bevy-sprite-07 = { package = "bevy_sprite", version = "0.7.0", default-features = false, optional = true }
 bevy_utils = { version = "0.7.0", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 anyhow = { version = "1.0", default-features = false, optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,14 @@ pub fn maintenance_systems() -> SystemSet {
 
 /// System set that animate the sprite-sheets
 pub fn animation_systems() -> SystemSet {
-    SystemSet::new().with_system(state::animate)
+    let mut set = SystemSet::new();
+
+    #[cfg(feature = "bevy-sprite-07")]
+    {
+        set = set.with_system(state::animate::<bevy_sprite_07::TextureAtlasSprite>);
+    }
+
+    set
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,8 @@ pub fn maintenance_systems() -> SystemSet {
 }
 
 /// System set that animate the sprite-sheets
+#[must_use]
+#[allow(unused_mut)]
 pub fn animation_systems() -> SystemSet {
     let mut set = SystemSet::new();
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -55,7 +55,7 @@ impl SpriteSheetAnimationState {
     /// Returns true if the animation has ended
     fn update(
         &mut self,
-        mut sprite: &mut impl SpriteState,
+        sprite: &mut impl SpriteState,
         animation: &SpriteSheetAnimation,
         delta: Duration,
     ) -> bool {
@@ -138,6 +138,7 @@ pub(crate) fn remove(
     }
 }
 
+#[allow(dead_code)]
 type AnimationSystemQuery<'a, T> = (
     Entity,
     &'a mut T,
@@ -146,6 +147,7 @@ type AnimationSystemQuery<'a, T> = (
     Option<&'a PlaySpeedMultiplier>,
 );
 
+#[allow(dead_code)]
 pub(crate) fn animate<T: SpriteState + Component>(
     mut commands: Commands<'_, '_>,
     time: Res<'_, Time>,


### PR DESCRIPTION
Follow up on #73 and the [decision of making bevy dependencies optional](https://github.com/jcornaz/benimator/blob/alpha/doc/adr/0002-optional-bevy-dependency.md).
