### PR TITLE
refactor: make `bevy_reflect` optional (behind `bevy-07` feature)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 [features]
 default = []
 unstable-load-from-file = ["serde", "anyhow"]
-bevy-07 = ["bevy-app-07", "bevy-asset-07", "bevy-sprite-07"]
+bevy-07 = ["bevy-reflect-07", "bevy-app-07", "bevy-asset-07", "bevy-sprite-07"]
 
 [dependencies]
 # Private dependencies (do not leak into the public API)
@@ -30,9 +30,9 @@ anyhow = { version = "1.0", default-features = false, optional = true }
 ## Bevy 0.7
 bevy_core = { version = "0.7.0", default-features = false }
 bevy_ecs = { version = "0.7.0", default-features = false }
-bevy_reflect = { version = "0.7.0", default-features = false }
 
 # Bevy 0.7
+bevy-reflect-07 = { package = "bevy_reflect", version = "0.7.0", default-features = false, optional = true }
 bevy-app-07 = { package = "bevy_app", version = "0.7.0", default-features = false, optional = true }
 bevy-asset-07 = { package = "bevy_asset", version = "0.7.0", default-features = false, optional = true }
 bevy-sprite-07 = { package = "bevy_sprite", version = "0.7.0", default-features = false, optional = true }

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -6,8 +6,6 @@ pub(crate) mod load;
 
 use std::{ops::RangeInclusive, time::Duration};
 
-use bevy_reflect::TypeUuid;
-
 #[cfg(feature = "unstable-load-from-file")]
 pub use load::SpriteSheetAnimationLoader;
 
@@ -20,13 +18,12 @@ use serde::Deserialize;
 /// Asset that define an animation of `TextureAtlasSprite`
 ///
 /// See crate level documentation for usage
-#[derive(Debug, Clone, Default, TypeUuid)]
+#[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "unstable-load-from-file", derive(Deserialize))]
 #[cfg_attr(
     feature = "unstable-load-from-file",
     serde(try_from = "parse::AnimationDto")
 )]
-#[uuid = "6378e9c2-ecd1-4029-9cd5-801caf68517c"]
 pub struct SpriteSheetAnimation {
     /// Frames
     pub(crate) frames: Vec<Frame>,

--- a/src/integration/bevy_07.rs
+++ b/src/integration/bevy_07.rs
@@ -9,6 +9,7 @@ use bevy_asset_07::prelude::*;
 use bevy_asset_07::{AssetLoader, BoxedFuture, LoadContext, LoadedAsset};
 use bevy_core::prelude::*;
 use bevy_ecs::prelude::*;
+use bevy_reflect_07::{TypeUuid, Uuid};
 use bevy_sprite_07::prelude::*;
 
 impl Plugin for crate::AnimationPlugin {
@@ -116,6 +117,13 @@ impl<'w, T: SpriteState> SpriteState for Mut<'w, T> {
     fn set_current_index(&mut self, index: usize) {
         self.deref_mut().set_current_index(index);
     }
+}
+
+impl TypeUuid for SpriteSheetAnimation {
+    const TYPE_UUID: Uuid = Uuid::from_bytes([
+        0x63, 0x78, 0xe9, 0xc2, 0xec, 0xd1, 0x40, 0x29, 0x9c, 0xd5, 0x80, 0x1c, 0xaf, 0x68, 0x51,
+        0x7c,
+    ]);
 }
 
 #[cfg(feature = "unstable-load-from-file")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,6 @@ extern crate rstest;
 
 use bevy_ecs::component::SparseStorage;
 use bevy_ecs::prelude::*;
-use bevy_reflect::Reflect;
 
 use std::time::Duration;
 
@@ -192,8 +191,7 @@ pub enum AnimationPostUpdateSystem {
 /// Insert the components to play the animation, and remove it to pause it.
 ///
 /// If the animation mode is [`AnimationMode::Once`] this component is automatically removed at the end of the animation.
-#[derive(Debug, Copy, Clone, Default, Reflect)]
-#[reflect(Component)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct Play;
 
 impl Component for Play {
@@ -203,8 +201,7 @@ impl Component for Play {
 /// Component that, when applied, can change the playback's rate of the animation.
 ///
 /// Receives a f64 multiplier which will alter the delta, speeding up or slowing down to the desired playback rate.
-#[derive(Debug, Copy, Component, Clone, Reflect)]
-#[reflect(Component)]
+#[derive(Debug, Copy, Component, Clone)]
 pub struct PlaySpeedMultiplier(f64);
 
 impl PlaySpeedMultiplier {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! 1. Add the [`AnimationPlugin`] plugin
 //!
 #![cfg_attr(
-    feature = "bevy-app-07",
+    feature = "bevy-07",
     doc = "
 ```no_run
 # use bevy::prelude::*;
@@ -37,31 +37,33 @@ fn spawn() { /* ... */ }
 //!
 //!
 //! 2. Create a [`SpriteSheetAnimation`] and insert the asset handle to the sprite sheet entity you want to animate
-//!
-//! ```
-//! # use std::time::Duration;
-//! # use bevy::prelude::*;
-//! # use benimator::*;
-//!
-//! fn spawn(mut commands: Commands, mut animations: ResMut<Assets<SpriteSheetAnimation>>) {
-//!
-//!     // Create an animation
-//!     let animation_handle = animations.add(SpriteSheetAnimation::from_range(
-//!         0..=2,                               // Indices of the sprite atlas
-//!         Duration::from_secs_f64(1.0 / 12.0), // Duration of each frame
-//!     ));
-//!
-//!     commands
-//!         .spawn_bundle(SpriteSheetBundle {
-//!             // TODO: Configure the sprite sheet
-//!             ..Default::default()
-//!         })
-//!         // Insert the asset handle of the animation
-//!         .insert(animation_handle)
-//!         // Start the animation immediately
-//!         .insert(Play);
-//! }
-//! ```
+#![cfg_attr(
+    feature = "bevy-07",
+    doc = "
+```
+# use std::time::Duration;
+# use bevy::prelude::*;
+# use benimator::*;
+
+fn spawn(mut commands: Commands, mut animations: ResMut<Assets<SpriteSheetAnimation>>) {
+    // Create an animation
+    let animation_handle = animations.add(SpriteSheetAnimation::from_range(
+        0..=2,                               // Indices of the sprite atlas
+        Duration::from_secs_f64(1.0 / 12.0), // Duration of each frame
+    ));
+    commands
+        .spawn_bundle(SpriteSheetBundle {
+            // TODO: Configure the sprite sheet
+            ..Default::default()
+        })
+        // Insert the asset handle of the animation
+        .insert(animation_handle)
+        // Start the animation immediately
+        .insert(Play);
+}
+```
+"
+)]
 //!
 //! ## Run the animation only once
 //!
@@ -136,15 +138,19 @@ fn spawn() { /* ... */ }
 //!     duration: 200
 //! ```
 //!
-//! And then load it with bevy's `AssetServer`:
-//! ```
-//! # use bevy::prelude::*;
-//! # use benimator::*;
-//! # fn load(mut commands: Commands, asset_server: Res<AssetServer>) {
-//! let handle: Handle<SpriteSheetAnimation> = asset_server.load("player_run.animation.yml");
-//! # }
-//! ```
-//!
+#![cfg_attr(
+    feature = "bevy-07",
+    doc = r#"
+And then load it with bevy's `AssetServer`:
+```
+# use bevy::prelude::*;
+# use benimator::*;
+# fn load(mut commands: Commands, asset_server: Res<AssetServer>) {
+let handle: Handle<SpriteSheetAnimation> = asset_server.load("player_run.animation.yml");
+# }
+```
+"#
+)]
 //! It is also possible to use `ron` instead of `yaml`.
 //!
 //! For more info on the format see: [`SpriteSheetAnimation::from_yaml_str`] and [`SpriteSheetAnimation::from_ron_str`].


### PR DESCRIPTION
The dependency `bevy_reflect` is now optional (behind the `bevy-07` feature).

I also removed the implementation of `Reflect` for the components that has been added eagerly without explicit need. And I am especially not enthusiast to implement `Reflect` without a very compelling reason, due to how many technical details are leaked by such implementation (which prevents changing the implementation without breaking API)

If you miss the `Reflect` implementation on benimator's components, you may open an issue. Please describe which component you'd need to implement `Reflect` and why.