### PR TITLE
refactor: make `bevy_ecs` and `bevy_core` deps optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 [features]
 default = []
 unstable-load-from-file = ["serde", "anyhow"]
-bevy-07 = ["bevy-reflect-07", "bevy-app-07", "bevy-asset-07", "bevy-sprite-07"]
+bevy-07 = ["bevy-ecs-07", "bevy-core-07", "bevy-reflect-07", "bevy-app-07", "bevy-asset-07", "bevy-sprite-07"]
 
 [dependencies]
 # Private dependencies (do not leak into the public API)
@@ -28,10 +28,8 @@ serde = { version = "1.0", default-features = false, features = ["derive"], opti
 anyhow = { version = "1.0", default-features = false, optional = true }
 
 ## Bevy 0.7
-bevy_core = { version = "0.7.0", default-features = false }
-bevy_ecs = { version = "0.7.0", default-features = false }
-
-# Bevy 0.7
+bevy-ecs-07 = { package = "bevy_ecs", version = "0.7.0", default-features = false, optional = true }
+bevy-core-07 = { package = "bevy_core", version = "0.7.0", default-features = false, optional = true }
 bevy-reflect-07 = { package = "bevy_reflect", version = "0.7.0", default-features = false, optional = true }
 bevy-app-07 = { package = "bevy_app", version = "0.7.0", default-features = false, optional = true }
 bevy-asset-07 = { package = "bevy_asset", version = "0.7.0", default-features = false, optional = true }

--- a/src/integration/bevy_07.rs
+++ b/src/integration/bevy_07.rs
@@ -4,13 +4,28 @@ use bevy_app_07::prelude::*;
 use bevy_asset_07::prelude::*;
 #[cfg(feature = "unstable-load-from-file")]
 use bevy_asset_07::{AssetLoader, BoxedFuture, LoadContext, LoadedAsset};
-use bevy_core::prelude::*;
-use bevy_ecs::prelude::*;
-use bevy_ecs::system::Resource;
+use bevy_core_07::prelude::*;
+use bevy_ecs_07::{
+    component::{SparseStorage, TableStorage},
+    prelude::*,
+    system::Resource,
+};
 use bevy_reflect_07::{TypeUuid, Uuid};
 use bevy_sprite_07::prelude::*;
 
 use crate::{Play, PlaySpeedMultiplier, SpriteSheetAnimation, SpriteSheetAnimationState};
+
+impl Component for Play {
+    type Storage = SparseStorage;
+}
+
+impl Component for PlaySpeedMultiplier {
+    type Storage = SparseStorage;
+}
+
+impl Component for SpriteSheetAnimationState {
+    type Storage = TableStorage;
+}
 
 trait TimeResource: Resource {
     fn delta_time(&self) -> Duration;
@@ -144,7 +159,7 @@ mod tests {
     use std::time::Duration;
 
     use bevy_asset_07::AssetPlugin;
-    use bevy_core::CorePlugin;
+    use bevy_core_07::CorePlugin;
 
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,18 +103,20 @@ fn spawn(mut commands: Commands, mut animations: ResMut<Assets<SpriteSheetAnimat
 //!
 //! For each entity with a [`SpriteSheetAnimation`], a [`SpriteSheetAnimationState`] component is automatically inserted.
 //! It can be used to reset the animation state by calling [`SpriteSheetAnimationState::reset`]
-//!
-//! ```
-//! # use bevy::prelude::*;
-//! # use benimator::SpriteSheetAnimationState;
-//!
-//! fn restart_anim_from_start(mut query: Query<&mut SpriteSheetAnimationState>) {
-//!   for mut state in query.iter_mut() {
-//!     state.reset();
-//!   }
-//! }
-//! ```
-//!
+#![cfg_attr(
+    feature = "bevy-07",
+    doc = "
+```
+# use bevy::prelude::*;
+# use benimator::SpriteSheetAnimationState;
+fn restart_anim_from_start(mut query: Query<&mut SpriteSheetAnimationState>) {
+  for mut state in query.iter_mut() {
+    state.reset();
+  }
+}
+```
+"
+)]
 //! ## Load animation from file **(Unstable)**
 //!
 //! By enabling the cargo feature: `unstable-load-from-file` you can write the animation in an asset file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,9 +159,6 @@ let handle: Handle<SpriteSheetAnimation> = asset_server.load("player_run.animati
 #[macro_use]
 extern crate rstest;
 
-use bevy_ecs::component::SparseStorage;
-use bevy_ecs::prelude::*;
-
 use std::time::Duration;
 
 pub use animation::{Frame, SpriteSheetAnimation};
@@ -192,14 +189,10 @@ pub struct AnimationPlugin;
 #[derive(Debug, Copy, Clone, Default)]
 pub struct Play;
 
-impl Component for Play {
-    type Storage = SparseStorage;
-}
-
 /// Component that, when applied, can change the playback's rate of the animation.
 ///
 /// Receives a f64 multiplier which will alter the delta, speeding up or slowing down to the desired playback rate.
-#[derive(Debug, Copy, Component, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct PlaySpeedMultiplier(f64);
 
 impl PlaySpeedMultiplier {

--- a/src/state.rs
+++ b/src/state.rs
@@ -7,17 +7,20 @@ use crate::{animation::Mode, Frame, SpriteSheetAnimation};
 /// It can be used to reset the animation state.
 ///
 /// # Example
-///
-/// ```
-/// # use bevy::prelude::*;
-/// # use benimator::SpriteSheetAnimationState;
-///
-/// fn restart_anim_from_start(mut query: Query<&mut SpriteSheetAnimationState>) {
-///   for mut state in query.iter_mut() {
-///     state.reset();
-///   }
-/// }
-/// ```
+#[cfg_attr(
+    feature = "bevy-07",
+    doc = "
+```
+# use bevy::prelude::*;
+# use benimator::SpriteSheetAnimationState;
+fn restart_anim_from_start(mut query: Query<&mut SpriteSheetAnimationState>) {
+  for mut state in query.iter_mut() {
+    state.reset();
+  }
+}
+```
+"
+)]
 #[derive(Default)]
 pub struct SpriteSheetAnimationState {
     animation_frame_index: usize,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,5 @@
 use std::time::Duration;
 
-use bevy_ecs::prelude::*;
-
 use crate::{animation::Mode, Frame, SpriteSheetAnimation};
 
 /// Animation state component which is automatically inserted/removed
@@ -20,7 +18,7 @@ use crate::{animation::Mode, Frame, SpriteSheetAnimation};
 ///   }
 /// }
 /// ```
-#[derive(Default, Component)]
+#[derive(Default)]
 pub struct SpriteSheetAnimationState {
     animation_frame_index: usize,
     elapsed_in_frame: Duration,


### PR DESCRIPTION
Final step for  having the bevy dependencies completely optional (see [the related decision](https://github.com/jcornaz/benimator/blob/main/doc/adr/0002-optional-bevy-dependency.md))