### PR TITLE
feat: stabilize load-from-file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,8 +68,8 @@ jobs:
     strategy:
       matrix:
         feature:
-          - "unstable-load-from-file, yaml"
-          - "unstable-load-from-file, ron"
+          - "load-from-file, yaml"
+          - "load-from-file, ron"
           - "bevy-07"
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,8 +68,9 @@ jobs:
     strategy:
       matrix:
         feature:
-          - "load-from-file, yaml"
-          - "load-from-file, ron"
+          - "serde"
+          - "yaml"
+          - "ron"
           - "bevy-07"
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,10 @@ all-features = true
 
 [features]
 default = []
-unstable-load-from-file = ["serde", "anyhow"]
+yaml = ["dep:yaml", "load-from-file"]
+ron = ["dep:ron", "load-from-file"]
 bevy-07 = ["bevy-ecs-07", "bevy-core-07", "bevy-reflect-07", "bevy-app-07", "bevy-asset-07", "bevy-sprite-07"]
+load-from-file = ["serde", "anyhow"]
 
 [dependencies]
 # Private dependencies (do not leak into the public API)
@@ -66,4 +68,4 @@ required-features = ["bevy-07"]
 
 [[example]]
 name = "using_animation_file"
-required-features = ["unstable-load-from-file", "yaml", "bevy-07"]
+required-features = ["load-from-file", "yaml", "bevy-07"]

--- a/README.md
+++ b/README.md
@@ -80,15 +80,14 @@ cargo add benimator
 
 ## Cargo features
 
-* `yaml` deserialization from yaml asset files (also requires `unstable-load-from-file`)
-* `ron` deserialization from ron asset files (also requires `unstable-load-from-file`)
-* `bevy-07` all integrations with bevy 0.7
+| Feature | Description |
+|---------|-------------|
+| `serde` | Implementation of serde traits for deserializaion 
+| `yaml` | Asset loader for yaml files
+| `ron` | Asset loader for ron files
+| `bevy-07` | Integration with bevy 0.7
 
-### Unstable features
-
-**Any API behind one of theses feature flags is unstable, should not be considered complete nor part of the public API. Breaking changes to that API may happen in minor releases**
-
-* `unstable-load-from-file` Load animation assets from yaml/ron files. It also requires either `ron` or `yaml` (or both) features.
+*Feature flags not mentioned here are **NOT** part of the public API and are subject to breaking changes.*
 
 ## MSRV
 

--- a/src/animation/dto.rs
+++ b/src/animation/dto.rs
@@ -124,22 +124,3 @@ impl Display for InvalidAnimation {
 }
 
 impl Error for InvalidAnimation {}
-
-/// Error when parsing an animation file content
-#[derive(Debug)]
-#[non_exhaustive]
-pub struct AnimationParseError(pub(crate) anyhow::Error);
-
-impl AnimationParseError {
-    pub(super) fn new(err: impl Error + Send + Sync + 'static) -> Self {
-        Self(anyhow::Error::from(err))
-    }
-}
-
-impl Display for AnimationParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "Animation format is invalid: {}", self.0)
-    }
-}
-
-impl Error for AnimationParseError {}

--- a/src/animation/load.rs
+++ b/src/animation/load.rs
@@ -1,8 +1,9 @@
-use std::{error::Error, fmt::Display};
+use std::{
+    error::Error,
+    fmt::{self, Display},
+};
 
 use crate::SpriteSheetAnimation;
-
-use super::AnimationParseError;
 
 /// Loader of animation file
 ///
@@ -121,6 +122,25 @@ impl SpriteSheetAnimationLoader {
 
             _ => Err(AnimationParseError(UnexpectedExtension.into())),
         }
+    }
+}
+
+/// Error when parsing an animation file content
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct AnimationParseError(anyhow::Error);
+
+impl Display for AnimationParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Animation format is invalid: {}", self.0)
+    }
+}
+
+impl Error for AnimationParseError {}
+
+impl AnimationParseError {
+    fn new(err: impl Error + Send + Sync + 'static) -> Self {
+        Self(anyhow::Error::from(err))
     }
 }
 

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -1,29 +1,26 @@
-#[cfg(feature = "unstable-load-from-file")]
+#[cfg(feature = "serde")]
 mod dto;
 
-#[cfg(feature = "unstable-load-from-file")]
+#[cfg(feature = "load-from-file")]
 pub(crate) mod load;
 
 use std::{ops::RangeInclusive, time::Duration};
 
-#[cfg(feature = "unstable-load-from-file")]
+#[cfg(feature = "load-from-file")]
 pub use load::SpriteSheetAnimationLoader;
 
-#[cfg(feature = "unstable-load-from-file")]
-pub use dto::AnimationParseError;
+#[cfg(feature = "load-from-file")]
+pub use load::AnimationParseError;
 
-#[cfg(feature = "unstable-load-from-file")]
+#[cfg(feature = "serde")]
 use serde::Deserialize;
 
 /// Asset that define an animation of `TextureAtlasSprite`
 ///
 /// See crate level documentation for usage
 #[derive(Debug, Clone, Default)]
-#[cfg_attr(feature = "unstable-load-from-file", derive(Deserialize))]
-#[cfg_attr(
-    feature = "unstable-load-from-file",
-    serde(try_from = "dto::AnimationDto")
-)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "dto::AnimationDto"))]
 pub struct SpriteSheetAnimation {
     /// Frames
     pub(crate) frames: Vec<Frame>,

--- a/src/integration/bevy_07.rs
+++ b/src/integration/bevy_07.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use bevy_app_07::prelude::*;
 use bevy_asset_07::prelude::*;
-#[cfg(feature = "unstable-load-from-file")]
+#[cfg(feature = "load-from-file")]
 use bevy_asset_07::{AssetLoader, BoxedFuture, LoadContext, LoadedAsset};
 use bevy_core_07::prelude::*;
 use bevy_ecs_07::{
@@ -48,7 +48,7 @@ fn install<T: TimeResource>(app: &mut App) {
         .add_system_set_to_stage(CoreStage::PreUpdate, auto_insert_state())
         .add_system_to_stage(CoreStage::Update, animate::<T>);
 
-    #[cfg(feature = "unstable-load-from-file")]
+    #[cfg(feature = "load-from-file")]
     app.init_asset_loader::<crate::animation::load::SpriteSheetAnimationLoader>();
 }
 
@@ -133,7 +133,7 @@ impl TypeUuid for SpriteSheetAnimation {
     ]);
 }
 
-#[cfg(feature = "unstable-load-from-file")]
+#[cfg(feature = "load-from-file")]
 impl AssetLoader for crate::animation::load::SpriteSheetAnimationLoader {
     fn load<'a>(
         &'a self,
@@ -237,7 +237,7 @@ mod tests {
         );
     }
 
-    #[cfg(all(feature = "unstable-load-from-file", feature = "yaml"))]
+    #[cfg(all(feature = "load-from-file", feature = "yaml"))]
     #[rstest]
     fn load_asset_file(mut app: App) {
         let handle: Handle<SpriteSheetAnimation> = app

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ fn restart_anim_from_start(mut query: Query<&mut SpriteSheetAnimationState>) {
 )]
 //! ## Load animation from file **(Unstable)**
 //!
-//! By enabling the cargo feature: `unstable-load-from-file` you can write the animation in an asset file.
+//! By enabling the cargo feature: `load-from-file` you can write the animation in an asset file.
 //!
 //! First, create an asset file with the extension `.animation.yml`:
 //! ```yaml
@@ -170,7 +170,7 @@ pub use state::SpriteSheetAnimationState;
 #[allow(deprecated)]
 pub use animation::AnimationMode;
 
-#[cfg(feature = "unstable-load-from-file")]
+#[cfg(feature = "load-from-file")]
 pub use animation::{AnimationParseError, SpriteSheetAnimationLoader};
 
 mod animation;


### PR DESCRIPTION
Resolve #62 

The feature flag `unstable-load-from-file` is removed. only `ron` or `yaml` is necessary to enable load-from file.

This change also enables the use of `serde` alone deserialization without using the loader.