### PR TITLE
feat!: Allow to define the frame rate from FPS

### DIFF
--- a/examples/bevy.rs
+++ b/examples/bevy.rs
@@ -1,6 +1,6 @@
-use std::time::Duration;
-
 use bevy::{prelude::*, render::texture::ImageSettings};
+
+use benimator::FrameRate;
 
 // Create the animation component
 // Note: you may make the animation an asset instead of a component
@@ -29,9 +29,10 @@ fn spawn(
     commands.spawn_bundle(Camera2dBundle::default());
 
     // Create an animation
-    const FPS: f64 = 12.0;
-    let frame_duration: Duration = Duration::from_secs(1).div_f64(FPS);
-    let animation = Animation(benimator::Animation::from_range(0..=4, frame_duration));
+    let animation = Animation(benimator::Animation::from_range(
+        0..=4,
+        FrameRate::from_fps(12.0),
+    ));
 
     commands
         // Spawn a bevy sprite-sheet

--- a/src/animation/dto.rs
+++ b/src/animation/dto.rs
@@ -154,17 +154,17 @@ impl Error for InvalidAnimation {}
 mod tests {
     use super::*;
 
-    use crate::{animation::Mode, Frame};
+    use crate::{animation::Mode, Frame, FrameRate};
     use std::time::Duration;
 
     #[rstest]
     fn deserialize_serialize(
         #[values(
-            Animation::from_range(0..=2, Duration::from_secs(1)),
-            Animation::from_range(0..=2, Duration::from_secs(1)).once(),
-            Animation::from_range(0..=2, Duration::from_secs(1)).repeat(),
-            Animation::from_range(0..=2, Duration::from_secs(1)).repeat_from(1),
-            Animation::from_range(0..=2, Duration::from_secs(1)).ping_pong(),
+            Animation::from_range(0..=2, FrameRate::from_fps(2.0)),
+            Animation::from_range(0..=2, FrameRate::from_fps(2.0)).once(),
+            Animation::from_range(0..=2, FrameRate::from_fps(2.0)).repeat(),
+            Animation::from_range(0..=2, FrameRate::from_fps(2.0)).repeat_from(1),
+            Animation::from_range(0..=2, FrameRate::from_fps(2.0)).ping_pong(),
         )]
         animation: Animation,
     ) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,11 +21,10 @@
 //!
 //! ```
 //! use std::time::Duration;
-//! use benimator::{Animation, State};
+//! use benimator::{Animation, FrameRate, State};
 //!
 //! // Create an animation
-//! let frame_duration = Duration::from_millis(100);
-//! let animation = Animation::from_range(0..=3, frame_duration);
+//! let animation = Animation::from_range(0..=3, FrameRate::from_fps(10.0));
 //!
 //! // Get a new animation state
 //! let mut state = State::default();
@@ -42,7 +41,7 @@
 #[macro_use]
 extern crate rstest;
 
-pub use animation::{Animation, Frame};
+pub use animation::{Animation, Frame, FrameRate};
 pub use state::State;
 
 mod animation;

--- a/src/state.rs
+++ b/src/state.rs
@@ -105,10 +105,16 @@ impl State {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::FrameRate;
 
     #[fixture]
     fn frame_duration() -> Duration {
         Duration::from_secs(1)
+    }
+
+    #[fixture]
+    fn frame_rate(frame_duration: Duration) -> FrameRate {
+        FrameRate::from_frame_duration(frame_duration)
     }
 
     #[fixture]
@@ -117,8 +123,8 @@ mod tests {
     }
 
     #[rstest]
-    fn sprite_index(frame_duration: Duration) {
-        let animation = Animation::from_range(3..=5, frame_duration);
+    fn sprite_index(frame_rate: FrameRate) {
+        let animation = Animation::from_range(3..=5, frame_rate);
         let mut state = State::default();
         state.update(&animation, Duration::ZERO);
         assert_eq!(state.sprite_frame_index(), 3);
@@ -153,8 +159,8 @@ mod tests {
         use super::*;
 
         #[fixture]
-        fn animation(frame_duration: Duration) -> Animation {
-            Animation::from_range(0..=2, frame_duration)
+        fn animation(frame_rate: FrameRate) -> Animation {
+            Animation::from_range(0..=2, frame_rate)
         }
 
         #[fixture]
@@ -175,10 +181,10 @@ mod tests {
         #[rstest]
         fn updates_index_if_less_than_expected_index(
             mut state: State,
-            frame_duration: Duration,
+            frame_rate: FrameRate,
             smaller_duration: Duration,
         ) {
-            let animation = Animation::from_range(1..=3, frame_duration);
+            let animation = Animation::from_range(1..=3, frame_rate);
             state.update(&animation, smaller_duration);
             assert_eq!(state.sprite_frame_index(), 1);
         }
@@ -186,10 +192,10 @@ mod tests {
         #[rstest]
         fn updates_index_if_greater_than_expected_index(
             mut state: State,
-            frame_duration: Duration,
+            frame_rate: FrameRate,
             smaller_duration: Duration,
         ) {
-            let animation = Animation::from_range(1..=3, frame_duration);
+            let animation = Animation::from_range(1..=3, frame_rate);
             state.update(&animation, smaller_duration);
             assert_eq!(state.sprite_frame_index(), 1);
         }
@@ -341,8 +347,8 @@ mod tests {
             use super::*;
 
             #[fixture]
-            fn animation(frame_duration: Duration) -> Animation {
-                Animation::from_range(0..=1, frame_duration).ping_pong()
+            fn animation(frame_rate: FrameRate) -> Animation {
+                Animation::from_range(0..=1, frame_rate).ping_pong()
             }
 
             #[fixture]
@@ -379,8 +385,8 @@ mod tests {
             use super::*;
 
             #[fixture]
-            fn animation(frame_duration: Duration) -> Animation {
-                Animation::from_range(0..=2, frame_duration).ping_pong()
+            fn animation(frame_rate: FrameRate) -> Animation {
+                Animation::from_range(0..=2, frame_rate).ping_pong()
             }
 
             #[fixture]
@@ -409,8 +415,8 @@ mod tests {
         use super::*;
 
         #[fixture]
-        fn animation(frame_duration: Duration) -> Animation {
-            Animation::from_range(0..=1, frame_duration).once()
+        fn animation(frame_rate: FrameRate) -> Animation {
+            Animation::from_range(0..=1, frame_rate).once()
         }
 
         mod on_first_frame {


### PR DESCRIPTION
Now `Animation::from_iter` and `Animation::from_range` take a `FrameRate` instead of a duration.

The `FrameRate` can be created from a *frame duration* or a from a *fps* (frame-per-second).