### PR TITLE
feat!: Rename `from_range` and `from_iter` to `from_indices`

### DIFF
--- a/examples/bevy.rs
+++ b/examples/bevy.rs
@@ -29,7 +29,7 @@ fn spawn(
     commands.spawn_bundle(Camera2dBundle::default());
 
     // Create an animation
-    let animation = Animation(benimator::Animation::from_range(
+    let animation = Animation(benimator::Animation::from_indices(
         0..=4,
         FrameRate::from_fps(12.0),
     ));

--- a/src/animation/dto.rs
+++ b/src/animation/dto.rs
@@ -160,11 +160,11 @@ mod tests {
     #[rstest]
     fn deserialize_serialize(
         #[values(
-            Animation::from_range(0..=2, FrameRate::from_fps(2.0)),
-            Animation::from_range(0..=2, FrameRate::from_fps(2.0)).once(),
-            Animation::from_range(0..=2, FrameRate::from_fps(2.0)).repeat(),
-            Animation::from_range(0..=2, FrameRate::from_fps(2.0)).repeat_from(1),
-            Animation::from_range(0..=2, FrameRate::from_fps(2.0)).ping_pong(),
+            Animation::from_indices(0..=2, FrameRate::from_fps(2.0)),
+            Animation::from_indices(0..=2, FrameRate::from_fps(2.0)).once(),
+            Animation::from_indices(0..=2, FrameRate::from_fps(2.0)).repeat(),
+            Animation::from_indices(0..=2, FrameRate::from_fps(2.0)).repeat_from(1),
+            Animation::from_indices(0..=2, FrameRate::from_fps(2.0)).ping_pong(),
         )]
         animation: Animation,
     ) {

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -1,10 +1,10 @@
-#[cfg(feature = "serde")]
-mod dto;
-
-use std::{ops::RangeInclusive, time::Duration};
+use core::time::Duration;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "serde")]
+mod dto;
 
 /// Definition of an animation
 #[cfg_attr(
@@ -67,35 +67,44 @@ impl Animation {
         }
     }
 
-    /// Create a new animation from index-range, using the same frame duration for each frame.
-    ///
-    /// For more granular configuration, see [`from_frames`](Animation::from_frames)
-    ///
-    /// # Panics
-    ///
-    /// Panics if the duration is zero
-    #[must_use]
-    pub fn from_range(index_range: RangeInclusive<usize>, frame_rate: FrameRate) -> Self {
-        Self::from_iter(index_range, frame_rate)
-    }
-
     /// Create a new animation from an index iterator, using the same frame duration for each frame.
     ///
-    /// # Example
+    /// # Examples
     ///
-    /// You may use this to create a reversed animation:
+    /// From an index range
     /// ```
     /// # use benimator::{Animation, FrameRate};
     /// # use std::time::Duration;
-    /// let animation = Animation::from_iter((0..5).rev(), FrameRate::from_fps(12.));
+    /// let animation = Animation::from_indices(0..=5, FrameRate::from_fps(12.0));
     /// ```
     ///
-    /// For more granular configuration, see [`from_frames`](Animation::from_frames)
+    /// From an index array
+    /// ```
+    /// # use benimator::{Animation, FrameRate};
+    /// # use std::time::Duration;
+    /// let animation = Animation::from_indices([1, 2, 3, 4], FrameRate::from_fps(12.0));
+    /// ```
+    ///
+    /// Reversed animation:
+    /// ```
+    /// # use benimator::{Animation, FrameRate};
+    /// # use std::time::Duration;
+    /// let animation = Animation::from_indices((0..5).rev(), FrameRate::from_fps(12.0));
+    /// ```
+    ///
+    /// Chained ranges
+    /// ```
+    /// # use benimator::{Animation, FrameRate};
+    /// # use std::time::Duration;
+    /// let animation = Animation::from_indices((0..3).chain(10..15), FrameRate::from_fps(12.0));
+    /// ```
+    ///
+    /// To use different non-uniform frame-duration, see [`from_frames`](Animation::from_frames)
     ///
     /// # Panics
     ///
     /// Panics if the duration is zero
-    pub fn from_iter(indices: impl IntoIterator<Item = usize>, frame_rate: FrameRate) -> Self {
+    pub fn from_indices(indices: impl IntoIterator<Item = usize>, frame_rate: FrameRate) -> Self {
         indices
             .into_iter()
             .map(|index| Frame::new(index, frame_rate.frame_duration))
@@ -227,7 +236,7 @@ mod tests {
 
     #[test]
     fn extends() {
-        let mut anim = Animation::from_range(
+        let mut anim = Animation::from_indices(
             0..=0,
             FrameRate::from_frame_duration(Duration::from_secs(1)),
         );
@@ -244,8 +253,8 @@ mod tests {
     #[test]
     fn fps_frame_duration_equivalence() {
         assert_eq!(
-            Animation::from_range(1..=3, FrameRate::from_fps(10.0)),
-            Animation::from_range(
+            Animation::from_indices(1..=3, FrameRate::from_fps(10.0)),
+            Animation::from_indices(
                 1..=3,
                 FrameRate::from_frame_duration(Duration::from_millis(100))
             ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! use benimator::{Animation, FrameRate, State};
 //!
 //! // Create an animation
-//! let animation = Animation::from_range(0..=3, FrameRate::from_fps(10.0));
+//! let animation = Animation::from_indices(0..=3, FrameRate::from_fps(10.0));
 //!
 //! // Get a new animation state
 //! let mut state = State::default();

--- a/src/state.rs
+++ b/src/state.rs
@@ -124,7 +124,7 @@ mod tests {
 
     #[rstest]
     fn sprite_index(frame_rate: FrameRate) {
-        let animation = Animation::from_range(3..=5, frame_rate);
+        let animation = Animation::from_indices(3..=5, frame_rate);
         let mut state = State::default();
         state.update(&animation, Duration::ZERO);
         assert_eq!(state.sprite_frame_index(), 3);
@@ -160,7 +160,7 @@ mod tests {
 
         #[fixture]
         fn animation(frame_rate: FrameRate) -> Animation {
-            Animation::from_range(0..=2, frame_rate)
+            Animation::from_indices(0..=2, frame_rate)
         }
 
         #[fixture]
@@ -184,7 +184,7 @@ mod tests {
             frame_rate: FrameRate,
             smaller_duration: Duration,
         ) {
-            let animation = Animation::from_range(1..=3, frame_rate);
+            let animation = Animation::from_indices(1..=3, frame_rate);
             state.update(&animation, smaller_duration);
             assert_eq!(state.sprite_frame_index(), 1);
         }
@@ -195,7 +195,7 @@ mod tests {
             frame_rate: FrameRate,
             smaller_duration: Duration,
         ) {
-            let animation = Animation::from_range(1..=3, frame_rate);
+            let animation = Animation::from_indices(1..=3, frame_rate);
             state.update(&animation, smaller_duration);
             assert_eq!(state.sprite_frame_index(), 1);
         }
@@ -348,7 +348,7 @@ mod tests {
 
             #[fixture]
             fn animation(frame_rate: FrameRate) -> Animation {
-                Animation::from_range(0..=1, frame_rate).ping_pong()
+                Animation::from_indices(0..=1, frame_rate).ping_pong()
             }
 
             #[fixture]
@@ -386,7 +386,7 @@ mod tests {
 
             #[fixture]
             fn animation(frame_rate: FrameRate) -> Animation {
-                Animation::from_range(0..=2, frame_rate).ping_pong()
+                Animation::from_indices(0..=2, frame_rate).ping_pong()
             }
 
             #[fixture]
@@ -416,7 +416,7 @@ mod tests {
 
         #[fixture]
         fn animation(frame_rate: FrameRate) -> Animation {
-            Animation::from_range(0..=1, frame_rate).once()
+            Animation::from_indices(0..=1, frame_rate).once()
         }
 
         mod on_first_frame {


### PR DESCRIPTION
`Animation::from_range` and `Animation::from_iter` were synonyms. They are both renamed to `Animation::from_indices`.

It also add more examples describing the multiple ways to define the indices:

```rust
Animation::from_indices(0..=5, FrameRate::from_fps(12.0));
Animation::from_indices([1, 2, 3, 4], FrameRate::from_fps(12.0));
Animation::from_indices((0..5).rev(), FrameRate::from_fps(12.0));
Animation::from_indices((0..3).chain(10..15), FrameRate::from_fps(12.0));
```