### PR TITLE
feat!: use frame-rate in deserialization format

### DIFF
--- a/assets/coin.animation.yml
+++ b/assets/coin.animation.yml
@@ -1,3 +1,3 @@
 mode: Repeat
-frame_duration: 100
+rate: !Fps 12
 frames: [0, 1, 2, 3, 4]

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -203,7 +203,7 @@ impl FrameRate {
     ///
     /// This function will panic if `fps` is negative, zero or not finite.
     pub fn from_fps(fps: f64) -> Self {
-        assert!(fps.is_finite() && fps > 0.0, "Invalid FPS: ${fps}");
+        assert!(fps.is_finite() && fps > 0.0, "Invalid FPS: {fps}");
         Self {
             frame_duration: Duration::from_secs(1).div_f64(fps),
             is_total_duration: false,

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -100,11 +100,9 @@ impl Animation {
             .map(|index| Frame::new(index, frame_rate.frame_duration))
             .collect();
 
-        if frame_rate.is_total_duration {
-            #[allow(clippy::cast_precision_loss)]
-            let actual_duration = frame_rate.frame_duration.div_f64(anim.frames.len() as f64);
+        if let Some(duration) = frame_rate.frame_duration_from_frame_count(anim.frames.len()) {
             for frame in &mut anim.frames {
-                frame.duration = actual_duration;
+                frame.duration = duration;
             }
         }
 
@@ -227,6 +225,17 @@ impl FrameRate {
         Self {
             frame_duration: duration,
             is_total_duration: true,
+        }
+    }
+
+    /// returns `None` if the frame rate is not dependant on the frame count
+    /// Otherwise, returns the duration of a single frame
+    #[allow(clippy::cast_precision_loss)]
+    fn frame_duration_from_frame_count(self, frame_count: usize) -> Option<Duration> {
+        if self.is_total_duration {
+            Some(self.frame_duration.div_f64(frame_count as f64))
+        } else {
+            None
         }
     }
 }


### PR DESCRIPTION
Replace the top level `frame_duration` property with a `rate` which takes a rate enum (one of `TotalDuration`, `FrameDuration` or `Fps`).

So that it is now possible to define the FPS of the animation in serialized animations.

Note, that if the rate is defined that way, it has precedence over the duration defined on each frame.

## Remaining tasks

* [ ] Fail if there is a conflict between the top-level rate and a frame duration?
* [ ] Update the documentation