### PR TITLE
feat: derive `Clone` for `State`

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use crate::{animation::Mode, Animation, Frame};
 
 /// Animation state
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct State {
     animation_frame_index: usize,
     sprite_frame_index: usize,


### PR DESCRIPTION
Mostly to enable embedding `State` inside larger types that can then have other useful traits derived for them (e.g. `Builder` from `derive_builder` crate) which transitively require `Clone`.