### PR TITLE
fix: deserialization error when using the toml crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde_yaml = { version = "0.9.22", default-features = false }
 rstest = { version = "0.17.0", default-features = false }
 bevy = { version = "0.10.1", default-features = false, features = ["bevy_asset", "bevy_winit", "bevy_render", "bevy_sprite", "bevy_core_pipeline", "png", "x11", "dynamic_linking"] }
 anyhow = "1.0"
+toml = "0.7.5"
 
 [build-dependencies]
 rustc_version = "0.4.0"

--- a/src/animation/dto.rs
+++ b/src/animation/dto.rs
@@ -77,6 +77,18 @@ impl<'de> Deserialize<'de> for FrameDto {
                     .map_err(|_| de::Error::invalid_value(Unexpected::Unsigned(v), &self))
             }
 
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                v.try_into()
+                    .map(|index| FrameDto {
+                        index,
+                        duration: None,
+                    })
+                    .map_err(|_| de::Error::invalid_value(Unexpected::Signed(v), &self))
+            }
+
             fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
             where
                 A: MapAccess<'de>,

--- a/src/animation/dto.rs
+++ b/src/animation/dto.rs
@@ -216,9 +216,12 @@ mod tests {
         )]
         animation: Animation,
     ) {
-        let serialized: String = serde_yaml::to_string(&animation).unwrap();
-        let deserialized: Animation = serde_yaml::from_str(&serialized).unwrap();
-        assert_eq!(animation, deserialized);
+        let yaml: String = serde_yaml::to_string(&animation).unwrap();
+        let from_yaml: Animation = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(animation, from_yaml);
+        let toml: String = toml::to_string(&animation).unwrap();
+        let from_toml: Animation = toml::from_str(&toml).unwrap();
+        assert_eq!(animation, from_toml);
     }
 
     #[test]
@@ -435,7 +438,7 @@ mod tests {
     }
 
     #[test]
-    fn same_duration_for_all_frames_short_hand() {
+    fn same_duration_for_all_frames_short_hand_yaml() {
         // given
         let content = "
             frame_duration: 100
@@ -444,6 +447,28 @@ mod tests {
 
         // when
         let animation: Animation = serde_yaml::from_str(content).unwrap();
+
+        // then
+        assert_eq!(
+            animation.frames,
+            vec![
+                Frame::new(0, Duration::from_millis(100)),
+                Frame::new(1, Duration::from_millis(100)),
+                Frame::new(2, Duration::from_millis(100)),
+            ]
+        );
+    }
+
+    #[test]
+    fn same_duration_for_all_frames_short_hand_toml() {
+        // given
+        let content = "
+            frame_duration = 100
+            frames = [0, 1, 2]
+        ";
+
+        // when
+        let animation: Animation = toml::from_str(content).unwrap();
 
         // then
         assert_eq!(


### PR DESCRIPTION
The [`toml`](https://docs.rs/toml/latest/toml/#) use signed integer for number but `FrameDto` use only `visit_u64`.

- Add `visit_i64`.